### PR TITLE
Update 2.install-obd.md

### DIFF
--- a/zh-CN/2.install-obd.md
+++ b/zh-CN/2.install-obd.md
@@ -27,6 +27,8 @@ source /etc/profile.d/obd.sh
 
 * mysql-devel
 
+* pyinstaller
+
 Python2.7 使用以下命令安装：
 
 ```shell


### PR DESCRIPTION
need to install `pyinstaller` before run command `rpm/build.sh`, otherwise could get error like this.
```
Successfully installed mysql-connector-python-1.1.6 protobuf
rpm/build.sh: line 47: pyinstaller: command not found
```