### PR TITLE
Update 1.quickly-start-the-oceanbase-database.md

### DIFF
--- a/zh-CN/3.user-guide/1.quickly-start-the-oceanbase-database.md
+++ b/zh-CN/3.user-guide/1.quickly-start-the-oceanbase-database.md
@@ -5,7 +5,7 @@
 
 * 当前用户为 root。
 
-* `2882` 和 `2883` 端口没有被占用。
+* `2881`，`2882` 和 `2883` 端口没有被占用。
 
 * 您的机器内存不低于 `8 G`。
 
@@ -20,6 +20,6 @@
 ```shell
 obd cluster deploy c1 -c ./example/mini-local-example.yaml
 obd cluster start c1
-# 使用 MySQL 客户端链接到到 OceanBase 数据库。
-mysql -h127.1 -uroot -P2883
+# 使用 MySQL 客户端连接到 OceanBase 数据库。
+mysql -h127.1 -uroot -P2881
 ```


### PR DESCRIPTION
`mini-local-example.yaml` 示例文件中对外开放的是2881端口，而非obproxy的2883端口。